### PR TITLE
Build: Splits library and tool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,9 @@ dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.59)
 AC_INIT(ultraeasy, 1.0)
 
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
+LT_INIT
 
 AC_CANONICAL_SYSTEM
 AM_INIT_AUTOMAKE([-Wall])
@@ -16,4 +19,3 @@ AC_SEARCH_LIBS([clock_gettime], [rt])
 
 AC_CONFIG_FILES(Makefile src/Makefile test/Makefile)
 AC_OUTPUT
-

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,10 @@
-bin_PROGRAMS=ultraeasy
-ultraeasy_SOURCES=main.c ultraeasy.c ue_link.c util.c facade.c
+lib_LTLIBRARIES = libultraeasy.la
+libultraeasy_la_SOURCES = ultraeasy.c ue_link.c util.c facade.c
+libultraeasy_la_LDFLAGS = -version-info 0:0:0
 
+pkginclude_HEADERS = ultraeasy.h ue_link.h
+
+bin_PROGRAMS=ultraeasy
+ultraeasy_SOURCES = main.c
+ultraeasy_LDADD = libultraeasy.la
+ultraeasy_DEPENDENCIES = libultraeasy.la

--- a/src/ultraeasy.h
+++ b/src/ultraeasy.h
@@ -24,6 +24,10 @@
 
 #include "ue_link.h"
 
+#ifdef __cplusplus
+extern “C” {
+#endif
+
 typedef struct ultraeasy ultraeasy_t;
 
 typedef struct ultraeasy_record {
@@ -36,12 +40,15 @@ typedef struct ultraeasy_record {
 	} raw;
 } ultraeasy_record_t;
 
-ultraeasy_t *ultraeasy_open(const char *pathname);
+extern ultraeasy_t *ultraeasy_open(const char *pathname);
 time_t ultraeasy_read_rtc(ultraeasy_t *ultraeasy);
 char *ultraeasy_read_serial(ultraeasy_t *ultraeasy);
-char *ultraeasy_read_version(ultraeasy_t *ultraeasy);
-int ultraeasy_num_records(ultraeasy_t *ultraeasy);
-int ultraeasy_get_record(ultraeasy_t *ultraeasy, unsigned int num, ultraeasy_record_t *record);
-void ultraeasy_close(ultraeasy_t *ultraeasy);
+extern char *ultraeasy_read_version(ultraeasy_t *ultraeasy);
+extern int ultraeasy_num_records(ultraeasy_t *ultraeasy);
+extern int ultraeasy_get_record(ultraeasy_t *ultraeasy, unsigned int num, ultraeasy_record_t *record);
+extern void ultraeasy_close(ultraeasy_t *ultraeasy);
 
+#ifdef  __cplusplus
+}
+#endif
 #endif /* ULTRAEASY_H_ */


### PR DESCRIPTION
Dear Daniel,

This pull request addresses the first part of my initially proposed patch. 
- It modifies the autoconf and automake configuration to use libtool
  and split the library from the tool, and the tool now depends on libultraeasy.
- Also as per your suggestion on #2 , this adds the __cplusplus ifdef to the ultraeasy.h headers.

Related to the discussion if having 'extern' on all the exported functions
is/not a requirement; I don't have a strong opinion, the approach that I followed is just based
on the documentation I found here:
 https://www.gnu.org/software/libtool/manual/html_node/C-header-files.html

If you have any other approach/suggestion, please let me know
and I can adapt the code according to your preferences.

Signed-off-by: Jorge Niedbalski jnr@metaklass.org
